### PR TITLE
Explore/apollo client

### DIFF
--- a/app/apollo-client.js
+++ b/app/apollo-client.js
@@ -1,0 +1,7 @@
+import ApolloClient, { createNetworkInterface } from 'apollo-client'
+
+const apolloClient = new ApolloClient({
+  networkInterface: createNetworkInterface({ uri: 'http://localhost:3000/graphql' })
+})
+
+export default apolloClient

--- a/app/grid/components/grid-header.js
+++ b/app/grid/components/grid-header.js
@@ -5,8 +5,8 @@ import styles from '../styles/grid-header'
 export default function GridHeader (props) {
   return <div className={styles.container}>
     {
-      props.projects.map((proj) => {
-        return <div className={styles.projectHeader}>
+      props.projects.map((proj, i) => {
+        return <div key={i} className={styles.projectHeader}>
           <span className={styles.projectTitle}>{proj.title}</span>
         </div>
       })

--- a/app/grid/components/grid-header.js
+++ b/app/grid/components/grid-header.js
@@ -3,11 +3,15 @@ import React from 'react'
 import styles from '../styles/grid-header'
 
 export default function GridHeader (props) {
+  const title = (data, dataType) => {
+    return dataType === 'projects' ? data.title : data.firstName
+  }
+
   return <div className={styles.container}>
     {
-      props.projects.map((proj, i) => {
+      props.data.map((d, i) => {
         return <div key={i} className={styles.projectHeader}>
-          <span className={styles.projectTitle}>{proj.title}</span>
+          <span className={styles.projectTitle}>{title(d, props.dataType)}</span>
         </div>
       })
     }

--- a/app/grid/containers/grid.js
+++ b/app/grid/containers/grid.js
@@ -1,35 +1,36 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { graphql, compose } from 'react-apollo'
 
 import GridHeader from '../components/grid-header'
 import Grid from '../components/grid'
 
 import { getProjects } from '../../projects/actions'
 
+import { projectsQuery } from '../queries'
+
 import { getGridProps } from '../getters'
 
 import styles from '../styles/grid'
 
 class GridContainer extends React.Component {
-  componentWillMount () {
-    const { getProjects } = this.props
-
-    getProjects()
-  }
+  // componentWillMount () {
+  //   const { getProjects } = this.props
+  //
+  //   getProjects()
+  // }
 
   render () {
-    const { projects } = this.props
+    const { data } = this.props
 
     return <div className={styles.container}>
-      <GridHeader projects={projects} />
+      <GridHeader projects={data.loading ? [] : data.projects} />
       <Grid />
     </div>
   }
 }
 
-export default connect(
-  getGridProps,
-  {
-    getProjects
-  }
+export default compose(
+  graphql(projectsQuery),
+  connect(getGridProps, { getProjects })
 )(GridContainer)

--- a/app/grid/containers/grid.js
+++ b/app/grid/containers/grid.js
@@ -5,32 +5,27 @@ import { graphql, compose } from 'react-apollo'
 import GridHeader from '../components/grid-header'
 import Grid from '../components/grid'
 
-import { getProjects } from '../../projects/actions'
+import { toggleDataType } from '../../main/actions'
 
-import { projectsQuery } from '../queries'
+import { projectsDevelopersQuery } from '../queries'
 
 import { getGridProps } from '../getters'
 
 import styles from '../styles/grid'
 
 class GridContainer extends React.Component {
-  // componentWillMount () {
-  //   const { getProjects } = this.props
-  //
-  //   getProjects()
-  // }
-
   render () {
-    const { data } = this.props
+    const { data, dataType, toggleDataType } = this.props
 
     return <div className={styles.container}>
-      <GridHeader projects={data.loading ? [] : data.projects} />
+      <GridHeader data={data.loading ? [] : data[dataType]} dataType={dataType} />
       <Grid />
+      <button onClick={() => { toggleDataType() }}>TOGGLE</button>
     </div>
   }
 }
 
 export default compose(
-  graphql(projectsQuery),
-  connect(getGridProps, { getProjects })
+  graphql(projectsDevelopersQuery),
+  connect(getGridProps, { toggleDataType })
 )(GridContainer)

--- a/app/grid/getters.js
+++ b/app/grid/getters.js
@@ -1,7 +1,9 @@
 import { createStructuredSelector } from 'reselect'
 
+import { getDataType } from '../main/getters'
 import { getProjects } from '../projects/getters'
 
 export const getGridProps = createStructuredSelector({
+  dataType: getDataType,
   projects: getProjects
 })

--- a/app/grid/queries.js
+++ b/app/grid/queries.js
@@ -1,10 +1,14 @@
 import gql from 'graphql-tag'
 
-export const projectsQuery = gql`
-  query Projects {
+export const projectsDevelopersQuery = gql`
+  query ProjectsDeveloprs {
     projects {
       id
       title
+    }
+    developers {
+      id
+      firstName
     }
   }
 `

--- a/app/grid/queries.js
+++ b/app/grid/queries.js
@@ -1,0 +1,10 @@
+import gql from 'graphql-tag'
+
+export const projectsQuery = gql`
+  query Projects {
+    projects {
+      id
+      title
+    }
+  }
+`

--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Provider } from 'react-redux'
+// import { Provider } from 'react-redux'
+import { ApolloProvider } from 'react-apollo'
+
 import StyleSheet from 'stilr'
 
 import store from './store'
+import apolloClient from './apollo-client'
 
 import MainContainer from './main/containers/main'
 
@@ -17,8 +20,8 @@ const mount = document.createElement('app')
 document.body.appendChild(mount)
 
 ReactDOM.render(
-  <Provider store={store}>
+  <ApolloProvider store={store} client={apolloClient}>
     <MainContainer />
-  </Provider>,
+  </ApolloProvider>,
   document.body.querySelector('app')
 )

--- a/app/main/actions.js
+++ b/app/main/actions.js
@@ -1,0 +1,3 @@
+import { createAction } from 'redux-actions'
+
+export const toggleDataType = createAction('TOGGLE_DATA_TYPE')

--- a/app/main/getters.js
+++ b/app/main/getters.js
@@ -1,0 +1,3 @@
+import { createStructuredSelector } from 'reselect'
+
+export const getDataType = (state) => state.main.dataType

--- a/app/main/reducer.js
+++ b/app/main/reducer.js
@@ -1,12 +1,15 @@
 import { combineReducers } from 'redux'
 
-const dummyAppName = function (state = 'TEMPO', action) {
+// TODO: projects / developers should be an enum
+const dataType = function (state = 'projects', action) {
   switch (action.type) {
+    case 'TOGGLE_DATA_TYPE':
+      return state === 'projects' ? 'developers' : 'projects'
     default:
       return state
   }
 }
 
 export default combineReducers({
-  dummyAppName
+  dataType
 })

--- a/app/root-reducer.js
+++ b/app/root-reducer.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux'
+import apolloClient from './apollo-client'
 
 import MainReducer from './main/reducer'
 import ProjectsReducer from './projects/reducer'
 
 export default combineReducers({
   main: MainReducer,
-  projects: ProjectsReducer
+  projects: ProjectsReducer,
+  apollo: apolloClient.reducer()
 })

--- a/app/store.js
+++ b/app/store.js
@@ -1,10 +1,11 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
+import apolloClient from './apollo-client'
 
 import rootReducer from './root-reducer'
 
 const enhancer = compose(
-  applyMiddleware(thunk)
+  applyMiddleware(thunk, apolloClient.middleware())
 )
 
 export default createStore(rootReducer, enhancer)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
       "babelify"
     ]
   },
+  "standard": {
+    "parser": "babel-eslint"
+  },
   "author": "iainkirkpatrick",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
   "author": "iainkirkpatrick",
   "license": "ISC",
   "dependencies": {
+    "apollo-client": "^0.8.1",
+    "graphql-tag": "^1.2.3",
     "lodash": "^4.17.4",
     "react": "^15.4.2",
+    "react-apollo": "^0.9.0",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-actions": "^1.2.1",


### PR DESCRIPTION
enough of an exploration for now, I think apollo-client is worth persisting with for a while, unless / until it's magic is too much or it's inflexible.
At which point can do data-fetching by normal thunk methods (and probably have a generic fetching action to send data to /graphql)